### PR TITLE
ColorCameraCalibrationToROS tool

### DIFF
--- a/PhoXiAPI/ColorCameraCalibrationToROS/CMakeLists.txt
+++ b/PhoXiAPI/ColorCameraCalibrationToROS/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required (VERSION 3.10)
+
+if(POLICY CMP0054)
+    cmake_policy(SET CMP0054 NEW)
+endif()
+
+project(ColorCameraCalibrationToROS)
+
+set(CMAKE_RELEASE_POSTFIX "_Release")
+set(CMAKE_DEBUG_POSTFIX "_Debug")
+
+if (UNIX AND NOT APPLE)
+    add_compile_options(-std=c++1y)
+    add_compile_options(-pthread)
+endif(UNIX AND NOT APPLE)
+
+set(Files
+    ${ColorCameraCalibrationToROS_SOURCE_DIR}/ColorCameraCalibrationToROS.cpp
+    ${ColorCameraCalibrationToROS_SOURCE_DIR}/ReadMe.txt
+)
+
+add_executable(ColorCameraCalibrationToROS
+    ${Files}
+)
+
+if (NOT PHO_API_CMAKE_CONFIG_PATH)
+    set(PHO_API_CMAKE_CONFIG_PATH "$ENV{PHOXI_CONTROL_PATH}")
+endif()
+
+find_package(PhoXi REQUIRED CONFIG PATHS "${PHO_API_CMAKE_CONFIG_PATH}")
+
+target_link_libraries(ColorCameraCalibrationToROS
+    ${PHOXI_LIBRARY}
+    $<$<PLATFORM_ID:Linux>:rt>
+)
+
+if(MSVC)
+    add_custom_command(TARGET ColorCameraCalibrationToROS POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<$<CONFIG:Release>:${PHOXI_DLL_RELEASE}>
+            $<$<CONFIG:Debug>:${PHOXI_DLL_DEBUG}>
+            $<TARGET_FILE_DIR:ColorCameraCalibrationToROS>
+    )
+endif()
+
+target_include_directories(ColorCameraCalibrationToROS PUBLIC 
+    ${PHOXI_INCLUDE_DIRS}
+)

--- a/PhoXiAPI/ColorCameraCalibrationToROS/ColorCameraCalibrationToROS.cpp
+++ b/PhoXiAPI/ColorCameraCalibrationToROS/ColorCameraCalibrationToROS.cpp
@@ -1,0 +1,227 @@
+/*
+* Photoneo's API Example - ColorCameraCalibrationToROS.cpp
+* Prints ColorCamera calibration parameters in ROS compatible yaml format.
+* This is calibration for raw RGB image respecting currently set resolution.
+* Note that this is different from device computed RGB texture.
+*
+* Modified from ExtendRobotics's FrameCalibrationToROS
+*
+* Mofification Contributors:
+* - Bartosz Meglicki <bartosz.meglicki@extendrobotics.com> (2023)
+*/
+
+#include <vector>
+#include <string>
+#include <iostream>
+#include <sstream>
+
+#include "PhoXi.h"
+
+//Print out list of device info to standard output
+void printDeviceInfoList(const std::vector<pho::api::PhoXiDeviceInformation> &DeviceList);
+//Print out device info to standard output
+void printDeviceInfo(const pho::api::PhoXiDeviceInformation &DeviceInfo);
+//Print out calibration parameters
+void printFrameCalibParams(pho::api::PPhoXi &PhoXiDevice);
+//Print out scanning volume information
+void printMatrix(const std::string &Name, const pho::api::CameraMatrix64f &Matrix);
+// print out the distortion coefficients
+void printDistortionCoefficients(const std::vector<double>& distCoeffs);
+
+int main(int argc, char *argv[])
+{
+    pho::api::PhoXiFactory Factory;
+
+    //Check if the PhoXi Control Software is running
+    if (!Factory.isPhoXiControlRunning())
+    {
+        std::cerr << "PhoXi Control Software is not running" << std::endl;
+        return 0;
+    }
+
+    //Get List of available devices on the network
+    std::vector <pho::api::PhoXiDeviceInformation> DeviceList = Factory.GetDeviceList();
+    if (DeviceList.empty())
+    {
+        std::cerr << "PhoXi Factory has found 0 devices" << std::endl;
+        return 0;
+    }
+    printDeviceInfoList(DeviceList);
+
+    //Try to connect device opened in PhoXi Control, if any
+    pho::api::PPhoXi PhoXiDevice = Factory.CreateAndConnectFirstAttached();
+    if (PhoXiDevice)
+    {
+        std::cout << "# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: "
+            << (std::string) PhoXiDevice->HardwareIdentification << std::endl;
+    }
+    else
+    {
+        std::cout << "# You have no PhoXi device opened in PhoXi Control, the API Example will try to connect to first device in device list" << std::endl;
+        PhoXiDevice = Factory.CreateAndConnect(DeviceList.front().HWIdentification);
+    }
+
+    //Check if device was created
+    if (!PhoXiDevice)
+    {
+        std::cerr << "Your device was not created!" << std::endl;
+        return 0;
+    }
+
+    //Check if device is connected
+    if (!PhoXiDevice->isConnected())
+    {
+        std::cerr << "Your device is not connected" << std::endl;
+        return 0;
+    }
+
+    std::cout << std::endl;
+
+    //Print out calibration parameters from the frame
+    printFrameCalibParams(PhoXiDevice);
+
+    //Disconnect PhoXi device
+    PhoXiDevice->Disconnect();
+    return 0;
+}
+
+void printDeviceInfoList(const std::vector<pho::api::PhoXiDeviceInformation> &DeviceList)
+{
+    for (std::size_t i = 0; i < DeviceList.size(); ++i)
+    {
+        std::cout << "# Device: " << i << std::endl;
+        printDeviceInfo(DeviceList[i]);
+    }
+}
+
+void printDeviceInfo(const pho::api::PhoXiDeviceInformation &DeviceInfo)
+{
+    std::cout << "#  Name:                    " << DeviceInfo.Name << std::endl;
+    std::cout << "#  Hardware Identification: " << DeviceInfo.HWIdentification << std::endl;
+    std::cout << "#  Type:                    " << std::string(DeviceInfo.Type) << std::endl;
+    std::cout << "#  Firmware version:        " << DeviceInfo.FirmwareVersion << std::endl;
+    std::cout << "#  Variant:                 " << DeviceInfo.Variant << std::endl;
+    std::cout << "#  IsFileCamera:            " << (DeviceInfo.IsFileCamera ? "Yes" : "No") << std::endl;
+    std::cout << "#  Feature-Alpha:           " << (DeviceInfo.CheckFeature("Alpha") ? "Yes" : "No") << std::endl;
+    std::cout << "#  Feature-Color:           " << (DeviceInfo.CheckFeature("Color") ? "Yes" : "No") << std::endl;
+    std::cout << "#  Status:                  "
+        << (DeviceInfo.Status.Attached ? "Attached to PhoXi Control. " : "Not Attached to PhoXi Control. ")
+        << (DeviceInfo.Status.Ready ? "Ready to connect" : "Occupied")
+        << std::endl << std::endl;
+}
+
+void printFrameCalibParams(pho::api::PPhoXi& PhoXiDevice)
+{
+    if (!PhoXiDevice->isAcquiring())
+    {
+        PhoXiDevice->StartAcquisition();
+    }
+    int FrameID = PhoXiDevice->TriggerFrame();
+    if (FrameID < 0)
+    {
+        //If negative number is returned trigger was unsuccessful
+        std::cerr << "Trigger was unsuccessful! code=" << FrameID << std::endl;
+        return;
+    }
+
+    pho::api::PFrame Frame = PhoXiDevice->GetSpecificFrame(FrameID);
+
+    if(!Frame)
+    {
+        std::cerr << "Failed to retrieve the frame!" << std::endl;
+        return;
+    }
+
+    const pho::api::TextureRGB16 &ColorFrame = Frame->ColorCameraImage;
+
+    if(ColorFrame.Empty())
+    {
+        std::cerr << "Failed to retrieve the color camera image!" << std::endl
+                  << "Make sure that ColorCameraImage transfer is enabled in PhoXiControl" << std::endl
+                  << "Make sure that appriopriate settings for color camera are set" << std::endl;
+        return;
+    }
+
+    std::cout << "# ColorCameraImage (raw RGB, this is not depth aligned RGB texture!)" << std::endl;
+    std::cout << "# ColorCameraScale: " << Frame->Info.ColorCameraScale.Width << "x" << Frame->Info.ColorCameraScale.Height << std::endl;
+
+    std::cout << "image_width: " << ColorFrame.Size.Width << std::endl;
+    std::cout << "image_height: " << ColorFrame.Size.Height << std::endl;
+    std::cout << "camera_name: " << (std::string) PhoXiDevice->HardwareIdentification << std::endl;
+
+    printMatrix("camera_matrix", Frame->Info.ColorCameraMatrix);
+    printDistortionCoefficients(Frame->Info.ColorCameraDistortionCoefficients);
+
+    // rectification matrix - we are not stereo camera so we need identity
+    pho::api::CameraMatrix64f ID(std::vector<int>{3, 3});
+    ID[0][0] = 1.0, ID[0][1] = 0.0, ID[0][2] = 0.0;
+    ID[1][0] = 0.0, ID[1][1] = 1.0, ID[1][2] = 0.0;
+    ID[2][0] = 0.0, ID[2][1] = 0.0, ID[2][2] = 1.0;
+
+    printMatrix("rectification_matrix", ID);
+
+    // projection matrix - we don't have rectified image
+    // so P[1:3,1:3] = K and Tx = Ty = 0 where K is camera_matrix
+    pho::api::CameraMatrix64f P(std::vector<int>{3, 4});
+    const pho::api::CameraMatrix64f &K = Frame->Info.CameraMatrix;
+    for(int r=0;r<K.Size.Height;++r)
+      for(int c=0;c<K.Size.Width;++c)
+        P[r][c]=K[r][c];
+    // zero out Tx, Ty
+    P[0][3] = P[1][3] = P[2][3] = 0.0;
+
+    printMatrix("projection_matrix", P);
+}
+
+void printDistortionCoefficients(const std::vector<double> &distCoeffs)
+{
+    //plumb bob is k1, k2, p1, p2, k3
+    const uint LAST_PLUMB_BOB_INDEX = 4;
+    //last index is k3, 4th
+
+    for(uint i=0;i<distCoeffs.size();++i)
+      if(i > LAST_PLUMB_BOB_INDEX && distCoeffs[i] != 0.0)
+      {
+        std::cerr << "only plumb_bob (k1, k2, p1, p2, k3 " << " is supported now!" << std::endl
+                  << " different model detected!" << std::endl;
+        return;
+      }
+
+    std::cout << "distortion_model: plumb_bob" << std::endl;
+    std::cout << "distortion_coefficients: " << std::endl
+              << "  rows: 1" << std::endl
+              << "  cols: "  << LAST_PLUMB_BOB_INDEX+1 << std::endl
+              << "  data: [";
+
+    for(uint i=0;i<=LAST_PLUMB_BOB_INDEX;++i)
+    {
+      std::cout << distCoeffs[i];
+      if(i<LAST_PLUMB_BOB_INDEX)
+        std::cout << ", ";
+    }
+
+    std::cout << "]" << std::endl;
+}
+
+void printMatrix(const std::string &name, const pho::api::CameraMatrix64f &matrix)
+{
+    if (matrix.Empty()) {
+        std::cout << "  " << name << ": empty" << std::endl;
+        return;
+    }
+
+    std::cout << name << ": " << std::endl
+              << "  rows: " << matrix.Size.Height << std::endl
+              << "  cols: " << matrix.Size.Width << std::endl
+              << "  data: [";
+
+    for(int r=0;r<matrix.Size.Height;++r)
+      for(int c=0;c<matrix.Size.Width;++c)
+      {
+        std::cout << matrix[r][c];
+        if(! (r == matrix.Size.Height-1 && c == matrix.Size.Width -1) )
+          std::cout << ", ";
+      }
+
+    std::cout << "]" << std::endl;
+}

--- a/PhoXiAPI/ColorCameraCalibrationToROS/ReadMe.txt
+++ b/PhoXiAPI/ColorCameraCalibrationToROS/ReadMe.txt
@@ -1,0 +1,36 @@
+========================================================================
+    CONSOLE APPLICATION : ColorCameraCalibrationToROS Project Overview
+========================================================================
+
+This is a simple application that prints out ColorCamera ROS compatibe yaml frame calibration.
+This is calibration for raw RGB image respecting currently set color resolution.
+Note that this is different from device computed RGB texture.
+
+You will learn how to:
+
+* obtain ROS compatible ColorCamera calibration file
+
+How to build:
+
+1. Copy ColorCameraCalibrationToROS folder to a location with Read and Write
+   permissions (using the name <source>)
+2. Open CMake
+   2.1. Set Source code to <source>
+   2.2. Set Binaries to <source>/_build or any other writable location
+   2.3. Click Configure and Generate
+3. Build project
+
+How to use:
+1. Set camera parameters (ideally with ROS driver)
+2. Run PhoXiControl
+   2.1. Connect to a scanner
+   2.2. Make sure `Structure->ColorCameraImage` transfer is enabled
+   2.3. Make sure `ColorSettings->Resolution` is as desired
+3. Run ColorCameraCalibrationToROS application and redirect output to yaml file
+  3.1 e.g. `./ColorCameraCalibrationToROS > MyColorCalibration.yaml`
+
+The application will print out frame level calibration params of ColorCamera of the connected scanner.
+If not connected to any scanner, it will automatically connect to the first
+in PhoXiControl.
+
+/////////////////////////////////////////////////////////////////////////////

--- a/PhoXiAPI/FrameCalibrationToROS/CMakeLists.txt
+++ b/PhoXiAPI/FrameCalibrationToROS/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required (VERSION 3.10)
+
+if(POLICY CMP0054)
+    cmake_policy(SET CMP0054 NEW)
+endif()
+
+project(FrameCalibrationToROS)
+
+set(CMAKE_RELEASE_POSTFIX "_Release")
+set(CMAKE_DEBUG_POSTFIX "_Debug")
+
+if (UNIX AND NOT APPLE)
+    add_compile_options(-std=c++1y)
+    add_compile_options(-pthread)
+endif(UNIX AND NOT APPLE)
+
+set(Files
+    ${FrameCalibrationToROS_SOURCE_DIR}/FrameCalibrationToROS.cpp
+    ${FrameCalibrationToROS_SOURCE_DIR}/ReadMe.txt
+)
+
+add_executable(FrameCalibrationToROS
+    ${Files}
+)
+
+if (NOT PHO_API_CMAKE_CONFIG_PATH)
+    set(PHO_API_CMAKE_CONFIG_PATH "$ENV{PHOXI_CONTROL_PATH}")
+endif()
+
+find_package(PhoXi REQUIRED CONFIG PATHS "${PHO_API_CMAKE_CONFIG_PATH}")
+
+target_link_libraries(FrameCalibrationToROS
+    ${PHOXI_LIBRARY}
+    $<$<PLATFORM_ID:Linux>:rt>
+)
+
+if(MSVC)
+    add_custom_command(TARGET FrameCalibrationToROS POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<$<CONFIG:Release>:${PHOXI_DLL_RELEASE}>
+            $<$<CONFIG:Debug>:${PHOXI_DLL_DEBUG}>
+            $<TARGET_FILE_DIR:FrameCalibrationToROS>
+    )
+endif()
+
+target_include_directories(FrameCalibrationToROS PUBLIC 
+    ${PHOXI_INCLUDE_DIRS}
+)

--- a/PhoXiAPI/FrameCalibrationToROS/FrameCalibrationToROS.cpp
+++ b/PhoXiAPI/FrameCalibrationToROS/FrameCalibrationToROS.cpp
@@ -1,0 +1,212 @@
+/*
+* Photoneo's API Example - FrameCalibrationToROS.cpp
+* Prints calibration parameters in ROS compatible yaml format.
+*
+* Modified from Photoneo's GetISCalibParams
+*
+* Mofification Contributors:
+* - Bartosz Meglicki <bartosz.meglicki@extendrobotics.com> (2023)
+*/
+
+#include <vector>
+#include <string>
+#include <iostream>
+#include <sstream>
+
+#include "PhoXi.h"
+
+//Print out list of device info to standard output
+void printDeviceInfoList(const std::vector<pho::api::PhoXiDeviceInformation> &DeviceList);
+//Print out device info to standard output
+void printDeviceInfo(const pho::api::PhoXiDeviceInformation &DeviceInfo);
+//Print out calibration parameters
+void printFrameCalibParams(pho::api::PPhoXi &PhoXiDevice);
+//Print out scanning volume information
+void printMatrix(const std::string &Name, const pho::api::CameraMatrix64f &Matrix);
+// print out the distortion coefficients
+void printDistortionCoefficients(const std::vector<double>& distCoeffs);
+
+int main(int argc, char *argv[])
+{
+    pho::api::PhoXiFactory Factory;
+
+    //Check if the PhoXi Control Software is running
+    if (!Factory.isPhoXiControlRunning())
+    {
+        std::cerr << "PhoXi Control Software is not running" << std::endl;
+        return 0;
+    }
+
+    //Get List of available devices on the network
+    std::vector <pho::api::PhoXiDeviceInformation> DeviceList = Factory.GetDeviceList();
+    if (DeviceList.empty())
+    {
+        std::cerr << "PhoXi Factory has found 0 devices" << std::endl;
+        return 0;
+    }
+    printDeviceInfoList(DeviceList);
+
+    //Try to connect device opened in PhoXi Control, if any
+    pho::api::PPhoXi PhoXiDevice = Factory.CreateAndConnectFirstAttached();
+    if (PhoXiDevice)
+    {
+        std::cout << "# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: "
+            << (std::string) PhoXiDevice->HardwareIdentification << std::endl;
+    }
+    else
+    {
+        std::cout << "# You have no PhoXi device opened in PhoXi Control, the API Example will try to connect to first device in device list" << std::endl;
+        PhoXiDevice = Factory.CreateAndConnect(DeviceList.front().HWIdentification);
+    }
+
+    //Check if device was created
+    if (!PhoXiDevice)
+    {
+        std::cerr << "Your device was not created!" << std::endl;
+        return 0;
+    }
+
+    //Check if device is connected
+    if (!PhoXiDevice->isConnected())
+    {
+        std::cerr << "Your device is not connected" << std::endl;
+        return 0;
+    }
+
+    std::cout << std::endl;
+
+    //Print out calibration parameters from the frame
+    printFrameCalibParams(PhoXiDevice);
+
+    //Disconnect PhoXi device
+    PhoXiDevice->Disconnect();
+    return 0;
+}
+
+void printDeviceInfoList(const std::vector<pho::api::PhoXiDeviceInformation> &DeviceList)
+{
+    for (std::size_t i = 0; i < DeviceList.size(); ++i)
+    {
+        std::cout << "# Device: " << i << std::endl;
+        printDeviceInfo(DeviceList[i]);
+    }
+}
+
+void printDeviceInfo(const pho::api::PhoXiDeviceInformation &DeviceInfo)
+{
+    std::cout << "#  Name:                    " << DeviceInfo.Name << std::endl;
+    std::cout << "#  Hardware Identification: " << DeviceInfo.HWIdentification << std::endl;
+    std::cout << "#  Type:                    " << std::string(DeviceInfo.Type) << std::endl;
+    std::cout << "#  Firmware version:        " << DeviceInfo.FirmwareVersion << std::endl;
+    std::cout << "#  Variant:                 " << DeviceInfo.Variant << std::endl;
+    std::cout << "#  IsFileCamera:            " << (DeviceInfo.IsFileCamera ? "Yes" : "No") << std::endl;
+    std::cout << "#  Feature-Alpha:           " << (DeviceInfo.CheckFeature("Alpha") ? "Yes" : "No") << std::endl;
+    std::cout << "#  Feature-Color:           " << (DeviceInfo.CheckFeature("Color") ? "Yes" : "No") << std::endl;
+    std::cout << "#  Status:                  "
+        << (DeviceInfo.Status.Attached ? "Attached to PhoXi Control. " : "Not Attached to PhoXi Control. ")
+        << (DeviceInfo.Status.Ready ? "Ready to connect" : "Occupied")
+        << std::endl << std::endl;
+}
+
+void printFrameCalibParams(pho::api::PPhoXi& PhoXiDevice)
+{
+    if (!PhoXiDevice->isAcquiring())
+    {
+        PhoXiDevice->StartAcquisition();
+    }
+    int FrameID = PhoXiDevice->TriggerFrame();
+    if (FrameID < 0)
+    {
+        //If negative number is returned trigger was unsuccessful
+        std::cerr << "Trigger was unsuccessful! code=" << FrameID << std::endl;
+        return;
+    }
+
+    pho::api::PFrame Frame = PhoXiDevice->GetSpecificFrame(FrameID);
+
+    if(!Frame)
+    {
+        std::cerr << "Failed to retrieve the frame!" << std::endl;
+        return;
+    }
+
+    std::cout << "image_width: " << Frame->GetResolution().Width << std::endl;
+    std::cout << "image_height: " << Frame->GetResolution().Height << std::endl;
+    std::cout << "camera_name: " << (std::string) PhoXiDevice->HardwareIdentification << std::endl;
+
+    printMatrix("camera_matrix", Frame->Info.CameraMatrix);
+    printDistortionCoefficients(Frame->Info.DistortionCoefficients);
+
+    // rectification matrix - we are not stereo camera so we need identity
+    pho::api::CameraMatrix64f ID(std::vector<int>{3, 3});
+    ID[0][0] = 1.0, ID[0][1] = 0.0, ID[0][2] = 0.0;
+    ID[1][0] = 0.0, ID[1][1] = 1.0, ID[1][2] = 0.0;
+    ID[2][0] = 0.0, ID[2][1] = 0.0, ID[2][2] = 1.0;
+
+    printMatrix("rectification_matrix", ID);
+
+    // projection matrix - we don't have rectified image
+    // so P[1:3,1:3] = K and Tx = Ty = 0 where K is camera_matrix
+    pho::api::CameraMatrix64f P(std::vector<int>{3, 4});
+    const pho::api::CameraMatrix64f &K = Frame->Info.CameraMatrix;
+    for(int r=0;r<K.Size.Height;++r)
+      for(int c=0;c<K.Size.Width;++c)
+        P[r][c]=K[r][c];
+    // zero out Tx, Ty
+    P[0][3] = P[1][3] = P[2][3] = 0.0;
+
+    printMatrix("projection_matrix", P);
+}
+
+void printDistortionCoefficients(const std::vector<double> &distCoeffs)
+{
+    //plumb bob is k1, k2, p1, p2, k3
+    const uint LAST_PLUMB_BOB_INDEX = 4;
+    //last index is k3, 4th
+
+    for(uint i=0;i<distCoeffs.size();++i)
+      if(i > LAST_PLUMB_BOB_INDEX && distCoeffs[i] != 0.0)
+      {
+        std::cerr << "only plumb_bob (k1, k2, p1, p2, k3 " << " is supported now!" << std::endl
+                  << " different model detected!" << std::endl;
+        return;
+      }
+
+    std::cout << "distortion_model: plumb_bob" << std::endl;
+    std::cout << "distortion_coefficients: " << std::endl
+              << "  rows: 1" << std::endl
+              << "  cols: "  << LAST_PLUMB_BOB_INDEX+1 << std::endl
+              << "  data: [";
+
+    for(uint i=0;i<=LAST_PLUMB_BOB_INDEX;++i)
+    {
+      std::cout << distCoeffs[i];
+      if(i<LAST_PLUMB_BOB_INDEX)
+        std::cout << ", ";
+    }
+
+    std::cout << "]" << std::endl;
+}
+
+void printMatrix(const std::string &name, const pho::api::CameraMatrix64f &matrix)
+{
+    if (matrix.Empty()) {
+        std::cout << "  " << name << ": empty" << std::endl;
+        return;
+    }
+
+    std::cout << name << ": " << std::endl
+              << "  rows: " << matrix.Size.Height << std::endl
+              << "  cols: " << matrix.Size.Width << std::endl
+              << "  data: [";
+
+    for(int r=0;r<matrix.Size.Height;++r)
+      for(int c=0;c<matrix.Size.Width;++c)
+      {
+        std::cout << matrix[r][c];
+        if(! (r == matrix.Size.Height-1 && c == matrix.Size.Width -1) )
+          std::cout << ", ";
+      }
+
+    std::cout << "]" << std::endl;
+}

--- a/PhoXiAPI/FrameCalibrationToROS/ReadMe.txt
+++ b/PhoXiAPI/FrameCalibrationToROS/ReadMe.txt
@@ -1,0 +1,33 @@
+========================================================================
+    CONSOLE APPLICATION : FrameCalibrationToROS Project Overview
+========================================================================
+
+This is a simple application that prints out ROS compatibe yaml frame calibration.
+
+You will learn how to:
+
+* obtain ROS compatible calibration file
+
+How to build:
+
+1. Copy FrameCalibrationToROS folder to a location with Read and Write
+   permissions (using the name <source>)
+2. Open CMake
+   2.1. Set Source code to <source>
+   2.2. Set Binaries to <source>/_build or any other writable location
+   2.3. Click Configure and Generate
+3. Build project
+
+How to use:
+1. Set camera parameters (ideally with ROS driver)
+2. Run PhoXiControl
+   2.1. Connect to a scanner
+   2.2. Make sure `OutputTopology == Regular grid` as this is required for optical model
+3. Run FrameCalibrationToROS application and redirect output to yaml file
+  3.1 e.g. `./FrameCalibrationToROS > MyCalibration.yaml`
+
+The application will print out frame level calibration params of the connected scanner.
+If not connected to any scanner, it will automatically connect to the first
+in PhoXiControl.
+
+/////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Small tool to dump color camera frame level calibration to ROS compatible yaml file

Typical usage
- set camera parameters (e.g. ROS driver)
  - don't forget to enable `ColorCamera` component and set desired resolution
- Start `PhoXi Control` 
- Connect to the camera

```bash
./ColorCameraCalibrationToROS > MyColorCalibration.yaml`
```

# Sample output

```yaml
# Device: 0
#  Name:                    MotionCam-3D-TRD-058
#  Hardware Identification: TRD-058
#  Type:                    MotionCam-3D
#  Firmware version:        1.10.1
#  Variant:                 M+
#  IsFileCamera:            No
#  Feature-Alpha:           No
#  Feature-Color:           Yes
#  Status:                  Attached to PhoXi Control. Ready to connect

# Device: 1
#  Name:                    basic-example
#  Hardware Identification: InstalledExamples-basic-example
#  Type:                    PhoXi3DScan
#  Firmware version:        
#  Variant:                 
#  IsFileCamera:            Yes
#  Feature-Alpha:           No
#  Feature-Color:           No
#  Status:                  Not Attached to PhoXi Control. Ready to connect

# Device: 2
#  Name:                    color-example
#  Hardware Identification: InstalledExamples-color-example
#  Type:                    MotionCam-3D
#  Firmware version:        
#  Variant:                 
#  IsFileCamera:            Yes
#  Feature-Alpha:           No
#  Feature-Color:           Yes
#  Status:                  Not Attached to PhoXi Control. Ready to connect

# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: TRD-058

# ColorCameraImage (raw RGB, this is not depth aligned RGB texture!)
# ColorCameraScale: 0.5x0.5
image_width: 1932
image_height: 1096
camera_name: TRD-058
camera_matrix: 
  rows: 3
  cols: 3
  data: [1343.28, 0, 955.571, 0, 1343.45, 544.948, 0, 0, 1]
distortion_model: plumb_bob
distortion_coefficients: 
  rows: 1
  cols: 5
  data: [0.0353329, -0.052106, -0.000742206, -0.000100143, 0.006824]
rectification_matrix: 
  rows: 3
  cols: 3
  data: [1, 0, 0, 0, 1, 0, 0, 0, 1]
projection_matrix: 
  rows: 3
  cols: 4
  data: [1158.77, 0, 569.003, 0, 0, 1158.7, 392.4, 0, 0, 0, 1, 0]
```